### PR TITLE
Added region option to getCompartment method

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -377,7 +377,7 @@ func (o *OCIDatasource) compartmentsResponse(ctx context.Context, tsdbReq *datas
 	json.Unmarshal([]byte(tsdbReq.Queries[0].ModelJson), &ts)
 	if o.timeCacheUpdated.IsZero() || now.Sub(o.timeCacheUpdated) > cacheRefreshTime {
 
-		m, err := o.getCompartments(ctx, ts.TenancyOCID)
+		m, err := o.getCompartments(ctx, ts.Region, ts.TenancyOCID)
 		if err != nil {
 			o.logger.Error("Unable to refresh cache")
 			return nil, err
@@ -414,10 +414,13 @@ func (o *OCIDatasource) compartmentsResponse(ctx context.Context, tsdbReq *datas
 	}, nil
 }
 
-func (o *OCIDatasource) getCompartments(ctx context.Context, rootCompartment string) (map[string]string, error) {
+func (o *OCIDatasource) getCompartments(ctx context.Context, region string, rootCompartment string) (map[string]string, error) {
 	m := make(map[string]string)
 	m["root compartment"] = rootCompartment
 	var page *string
+
+	reg := common.StringToRegion(region)
+	o.identityClient.SetRegion(string(reg))
 	for {
 		res, err := o.identityClient.ListCompartments(ctx,
 			identity.ListCompartmentsRequest{


### PR DESCRIPTION
Hi,

When OCI tenancy is provision with a single region, say 'us-phoenix-1' (home tenancy) and the datasource setting with local has the default regions as 'us-ausburn-1' (in the ~/.oci/config file), the getCompartment does not return the compartment list. The reason being the OCI tenancy has only one tenancy as home and that is not the 'us-phoenix-1' tenancy.

The fix is to set region to the home regions of the OCI tenancy, while making the getCompartment call.

Thanks,