### PR TITLE
Added auto option and variable support for window and resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oci-grafana-plugin",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,10 +2,12 @@
 ** Copyright © 2019 Oracle and/or its affiliates. All rights reserved.
 ** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 */
+export const AUTO = 'auto'
 export const regions = ['ca-toronto-1', 'eu-frankfurt-1', 'uk-london-1', 'us-ashburn-1', 'us-phoenix-1']
 export const namespaces = ['oci_computeagent', 'oci_blockstore', 'oci_lbaas', 'oci_telemetry']
 export const aggregations = ['count()', 'max()', 'mean()', 'min()', 'rate()', 'sum()', 'percentile(.90)', 'percentile(.95)', 'percentile(.99)']
-export const windows = ['1m', '5m', '1h']
+export const windows = [AUTO, '1m', '5m', '1h']
+export const resolutions = [AUTO, '1m', '5m', '1h']
 export const environments = ['local', 'OCI Instance']
 
 
@@ -16,6 +18,7 @@ export const resourcegroupsQueryRegex = /^resourcegroups\(\s*(\".+\"|\'.+\'|\$\w
 export const metricsQueryRegex = /^metrics\(\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*\)/;
 export const dimensionKeysQueryRegex = /^dimensions\(\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*\)/;
 export const dimensionValuesQueryRegex = /^dimensionOptions\(\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*,\s*(\".+\"|\'.+\'|\$\w+)\s*\)/;
+export const windowsAndResolutionRegex = /^[0-9]+[mhs]$/;
 
 export const removeQuotes = str => {
     if (!str) return str;
@@ -29,3 +32,18 @@ export const removeQuotes = str => {
     }
     return res;
 }
+
+// if the user selects a time range less than 7 days ->  window will be 1m and resolution will be 1 min
+//
+// if the user selects a time range less than 30 days and more than 7 days ->   window will be 5m and resolution will be 5 min.
+//
+//   if the user select time range less than 90 days and more than 30 days -> a window will be 1h and resolution will be 1 h
+
+const sevenDaysInMs = 7 * 24 * 60 * 60 * 1000
+const thirtyDaysInMs = 30 * 24 * 60 * 60 * 1000
+const ninetyDaysInMs = 90 * 24 * 60 * 60 * 1000
+export const autoTimeIntervals = [
+  [sevenDaysInMs, { window: '1m', resolution: '1m' }],
+  [thirtyDaysInMs, { window: '5m', resolution: '5m' }],
+  [ninetyDaysInMs, { window: '1h', resolution: '1h' }]
+]

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,11 +39,16 @@ export const removeQuotes = str => {
 //
 //   if the user select time range less than 90 days and more than 30 days -> a window will be 1h and resolution will be 1 h
 
-const sevenDaysInMs = 7 * 24 * 60 * 60 * 1000
-const thirtyDaysInMs = 30 * 24 * 60 * 60 * 1000
-const ninetyDaysInMs = 90 * 24 * 60 * 60 * 1000
+export const SEVEN_DAYS = 7
+export const THIRTY_DAYS = 30
+export const NINETY_DAYS = 90
+
+export const d0To7Config = { window: '1m', resolution: '1m' }
+export const d8To30Config = { window: '5m', resolution: '5m' }
+export const d31toInfConfig = { window: '1h', resolution: '1h' }
+
 export const autoTimeIntervals = [
-  [sevenDaysInMs, { window: '1m', resolution: '1m' }],
-  [thirtyDaysInMs, { window: '5m', resolution: '5m' }],
-  [ninetyDaysInMs, { window: '1h', resolution: '1h' }]
+  [SEVEN_DAYS, d0To7Config],
+  [THIRTY_DAYS, d8To30Config],
+  [NINETY_DAYS, d31toInfConfig]
 ]

--- a/src/datasource.js
+++ b/src/datasource.js
@@ -169,8 +169,8 @@ export default class OCIDatasource {
         let window = t.window === SELECT_PLACEHOLDERS.WINDOW ? '' : this.getVariableValue(t.window)
         resolution = this.getVariableValue(t.resolution)
         // p.s : timeSrv.timeRange() results in a moment object
-        const rangeInMs = this.timeSrv.timeRange().to - this.timeSrv.timeRange().from
-        const resolvedWinResolObj = resolveAutoWinRes(window, resolution, rangeInMs)
+        const numberOfDaysDiff = this.timeSrv.timeRange().to.diff(this.timeSrv.timeRange().from, 'days')
+        const resolvedWinResolObj = resolveAutoWinRes(window, resolution, numberOfDaysDiff)
         window = resolvedWinResolObj.window
         resolution = resolvedWinResolObj.resolution
         query = `${this.getVariableValue(t.metric, options.scopedVars)}[${window}]${dimension}.${t.aggregation}`
@@ -617,9 +617,10 @@ export default class OCIDatasource {
         const custom = vars.filter(item => item.type === 'custom' || item.type === 'constant');
         regexVars = regexVars.concat(custom);
       }
-      return regexVars;
+      const uniqueRegexVarsMap = new Map();
+      regexVars.forEach(varObj => uniqueRegexVarsMap.set(varObj.name, varObj))
+      return Array.from(uniqueRegexVarsMap.values())
     }
-
     return vars;
   }
 
@@ -634,7 +635,7 @@ export default class OCIDatasource {
   */
   getVariables(regex, includeCustom) {
     const varDescriptors = this.getVariableDescriptors(regex, includeCustom) || [];
-    return [ ...new Set(varDescriptors.map(item => `$${item.name}`))];
+    return varDescriptors.map(item => `$${item.name}`);
   }
 
   /**

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -65,10 +65,9 @@
           </div>
         </div>
         <div class="gf-form">
-          <label class="gf-form-label width-10 query-keyword">Window</label>
+          <label class="gf-form-label query-keyword">Window</label>
           <div class="gf-form-select-wrapper width-10">
             <gf-form-dropdown
-              class="gf-form-input"
               model="ctrl.target.window"
               get-options="ctrl.getWindows()"
               on-change="ctrl.onChangeInternal()"
@@ -76,10 +75,9 @@
           </div>
         </div>
         <div class="gf-form">
-          <label class="gf-form-label width-10 query-keyword">Resolution</label>
+          <label class="gf-form-label query-keyword">Resolution</label>
           <div class="gf-form-select-wrapper width-10">
             <gf-form-dropdown
-                    class="gf-form-input"
                     model="ctrl.target.resolution"
                     get-options="ctrl.getResolutions()"
                     on-change="ctrl.onChangeInternal()"

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -65,19 +65,26 @@
           </div>
         </div>
         <div class="gf-form">
-          <label class="gf-form-label query-keyword width-10">Window</label>
-          <div class="gf-form-select-wrapper max-width-20">
-            <select
+          <label class="gf-form-label width-10 query-keyword">Window</label>
+          <div class="gf-form-select-wrapper width-10">
+            <gf-form-dropdown
               class="gf-form-input"
-              ng-model="ctrl.target.window"
-              ng-options="o as o for o in ctrl.getWindows()"
-              ng-change="ctrl.onChangeInternal()">
-            </select>
+              model="ctrl.target.window"
+              get-options="ctrl.getWindows()"
+              on-change="ctrl.onChangeInternal()"
+            />
           </div>
         </div>
         <div class="gf-form">
           <label class="gf-form-label width-10 query-keyword">Resolution</label>
-          <input type="text" class="input-small gf-form-input width-5" ng-model="ctrl.target.resolution" ng-change="ctrl.onChangeInternal()" placeholder="1m"/>
+          <div class="gf-form-select-wrapper width-10">
+            <gf-form-dropdown
+                    class="gf-form-input"
+                    model="ctrl.target.resolution"
+                    get-options="ctrl.getResolutions()"
+                    on-change="ctrl.onChangeInternal()"
+            />
+          </div>
         </div>
       </div>
      <div class="gf-form-inline">
@@ -85,7 +92,7 @@
          <label class="gf-form-label query-keyword width-8">Dimensions</label>
        </div>
        <div class="gf-form" ng-repeat="segment in ctrl.dimensionSegments">
-        <metric-segment 
+        <metric-segment
           segment="segment"
           get-options="ctrl.getDimensionOptions(segment, $index)"
           on-change="ctrl.onDimensionsChange(segment, $index)"

--- a/src/query_ctrl.js
+++ b/src/query_ctrl.js
@@ -4,8 +4,17 @@
 */
 import { QueryCtrl } from 'app/plugins/sdk'
 import './css/query-editor.css!'
-import { windows, namespacesQueryRegex, resourcegroupsQueryRegex, metricsQueryRegex, regionsQueryRegex, compartmentsQueryRegex, dimensionKeysQueryRegex, dimensionValuesQueryRegex } from './constants'
-import _ from 'lodash'
+import {
+  windows,
+  namespacesQueryRegex,
+  resourcegroupsQueryRegex,
+  metricsQueryRegex,
+  regionsQueryRegex,
+  compartmentsQueryRegex,
+  dimensionKeysQueryRegex,
+  dimensionValuesQueryRegex,
+  windowsAndResolutionRegex, resolutions, AUTO
+} from './constants'
 
 export const SELECT_PLACEHOLDERS = {
   DIMENSION_KEY: 'select dimension',
@@ -14,8 +23,9 @@ export const SELECT_PLACEHOLDERS = {
   REGION: 'select region',
   NAMESPACE: 'select namespace',
   RESOURCEGROUP: 'select resource group',
-  METRIC: 'select metric'
-};
+  METRIC: 'select metric',
+  WINDOW: 'select window'
+}
 
 export class OCIDatasourceQueryCtrl extends QueryCtrl {
   constructor($scope, $injector, $q, uiSegmentSrv) {
@@ -29,8 +39,8 @@ export class OCIDatasourceQueryCtrl extends QueryCtrl {
     this.target.namespace = this.target.namespace || SELECT_PLACEHOLDERS.NAMESPACE;
     this.target.resourcegroup = this.target.resourcegroup || SELECT_PLACEHOLDERS.RESOURCEGROUP;
     this.target.metric = this.target.metric || SELECT_PLACEHOLDERS.METRIC;
-    this.target.resolution = this.target.resolution || '1m';
-    this.target.window = this.target.window || '1m';
+    this.target.resolution = this.target.resolution || AUTO;
+    this.target.window = this.target.window || AUTO;
     this.target.aggregation = this.target.aggregation || 'mean()'
     this.target.dimensions = this.target.dimensions || [];
 
@@ -93,8 +103,12 @@ export class OCIDatasourceQueryCtrl extends QueryCtrl {
     });
   }
 
-  getWindows() {
-    return windows;
+  getWindows () {
+    return this.appendWindowsAndResolutionVariables([...windows], windowsAndResolutionRegex)
+  }
+
+  getResolutions () {
+    return this.appendWindowsAndResolutionVariables([...resolutions], windowsAndResolutionRegex)
   }
 
   /**
@@ -169,6 +183,10 @@ export class OCIDatasourceQueryCtrl extends QueryCtrl {
     return options;
   }
 
+  appendWindowsAndResolutionVariables (options, varQeueryRegex) {
+    const vars = this.datasource.getVariables(varQeueryRegex) || []
+    return [...options, ...vars].map(value => ({ value, text: value }))
+  }
   // ****************************** Callbacks **********************************
 
   toggleEditorMode() {

--- a/src/util/utilFunctions.js
+++ b/src/util/utilFunctions.js
@@ -7,9 +7,9 @@ import { AUTO, autoTimeIntervals } from '../constants'
  * @param timeRange
  * @returns {{window, resolution}}
  */
-const getWindowAndResolution = (autoWinResConfig, timeRange) => {
-  let i = 0
-  do { i++ } while (i < autoWinResConfig.length - 1 && timeRange >= autoWinResConfig[i][0])
+export const getWindowAndResolution = (autoWinResConfig, timeRange) => {
+  let i = -1
+  do { i++ } while (i < autoWinResConfig.length - 1 && timeRange > autoWinResConfig[i][0])
   const { window, resolution } = autoWinResConfig[i][1]
   return { window, resolution }
 }
@@ -22,15 +22,10 @@ const getWindowAndResolution = (autoWinResConfig, timeRange) => {
  * @returns {{window: *, resolution: *}}
  */
 export const resolveAutoWinRes = (windowSelected, resolutionSelected, timeRangeSelected) => {
-  let { window, resolution } = getWindowAndResolution(autoTimeIntervals, timeRangeSelected)
-
   const result = { window: windowSelected, resolution: resolutionSelected }
-
-  if (windowSelected === AUTO) {
-    result.window = window
-  }
-  if (resolutionSelected === AUTO) {
-    result.resolution = resolution
-  }
+  if (windowSelected !== AUTO && resolutionSelected !== AUTO) return result
+  const { window, resolution } = getWindowAndResolution(autoTimeIntervals, timeRangeSelected)
+  if (windowSelected === AUTO) result.window = window
+  if (resolutionSelected === AUTO) result.resolution = resolution
   return result
 }

--- a/src/util/utilFunctions.js
+++ b/src/util/utilFunctions.js
@@ -1,0 +1,36 @@
+import { AUTO, autoTimeIntervals } from '../constants'
+
+/** getWindowAndResolution
+ *
+ * @param autoWinResConfig is an array of Object with length always greater than 1,
+ * i.e config array should contain at least 1 object
+ * @param timeRange
+ * @returns {{window, resolution}}
+ */
+const getWindowAndResolution = (autoWinResConfig, timeRange) => {
+  let i = 0
+  do { i++ } while (i < autoWinResConfig.length - 1 && timeRange >= autoWinResConfig[i][0])
+  const { window, resolution } = autoWinResConfig[i][1]
+  return { window, resolution }
+}
+
+/** resolveAutoWinRes
+ *
+ * @param windowSelected
+ * @param resolutionSelected
+ * @param timeRangeSelected
+ * @returns {{window: *, resolution: *}}
+ */
+export const resolveAutoWinRes = (windowSelected, resolutionSelected, timeRangeSelected) => {
+  let { window, resolution } = getWindowAndResolution(autoTimeIntervals, timeRangeSelected)
+
+  const result = { window: windowSelected, resolution: resolutionSelected }
+
+  if (windowSelected === AUTO) {
+    result.window = window
+  }
+  if (resolutionSelected === AUTO) {
+    result.resolution = resolution
+  }
+  return result
+}

--- a/src/util/utilFunctions.test.js
+++ b/src/util/utilFunctions.test.js
@@ -1,0 +1,66 @@
+import { getWindowAndResolution, resolveAutoWinRes } from './utilFunctions'
+import {
+  autoTimeIntervals,
+  SEVEN_DAYS,
+  THIRTY_DAYS,
+  d8To30Config,
+  d0To7Config,
+  d31toInfConfig,
+  AUTO
+} from '../constants'
+
+describe('getWindowAndResolution Tests : Test for config generation on days given', () => {
+  test('getWindowAndResolution : 0 days', () => {
+    expect(getWindowAndResolution(autoTimeIntervals, SEVEN_DAYS))
+      .toMatchObject(d0To7Config)
+  })
+  test('getWindowAndResolution : 1 day', () => {
+    expect(getWindowAndResolution(autoTimeIntervals, SEVEN_DAYS))
+      .toMatchObject(d0To7Config)
+  })
+  test('getWindowAndResolution : 7 days', () => {
+    expect(getWindowAndResolution(autoTimeIntervals, SEVEN_DAYS))
+      .toMatchObject(d0To7Config)
+  })
+  test('getWindowAndResolution : 14 days', () => {
+    const D14 = '14'
+    expect(getWindowAndResolution(autoTimeIntervals, D14))
+      .toMatchObject(d8To30Config)
+  })
+  test('getWindowAndResolution : 30 days', () => {
+    expect(getWindowAndResolution(autoTimeIntervals, THIRTY_DAYS))
+      .toMatchObject(d8To30Config)
+  })
+
+  test('getWindowAndResolution : 41 days', () => {
+    const D999 = '999'
+    expect(getWindowAndResolution(autoTimeIntervals, D999))
+      .toMatchObject(d31toInfConfig)
+  })
+})
+
+describe('resolveAutoWinRes Tests : Test to check replacement of auto with time duration with time duration ' +
+  'if auto is selected', () => {
+  const TIME_IN_DURATION = '5m'
+
+  test('resolveAutoWinRes : with auto mode on ', () => {
+    expect(resolveAutoWinRes(AUTO, AUTO, SEVEN_DAYS))
+      .toMatchObject(d0To7Config)
+  })
+
+  test('resolveAutoWinRes : with auto mode only on window, resolution given a time duration', () => {
+    expect(resolveAutoWinRes(AUTO, TIME_IN_DURATION, SEVEN_DAYS))
+      .toMatchObject({ window: d0To7Config.window, resolution: TIME_IN_DURATION })
+  })
+
+  test('resolveAutoWinRes : with auto mode only on resolution, window given a time duration', () => {
+    expect(resolveAutoWinRes(TIME_IN_DURATION, AUTO, SEVEN_DAYS))
+      .toMatchObject({ window: TIME_IN_DURATION, resolution: d0To7Config.resolution })
+  })
+
+  test('resolveAutoWinRes : with no auto', () => {
+    expect(resolveAutoWinRes(TIME_IN_DURATION, TIME_IN_DURATION, SEVEN_DAYS))
+      .toMatchObject({ window: TIME_IN_DURATION, resolution: TIME_IN_DURATION })
+  })
+}
+)


### PR DESCRIPTION
[CPD-378| Add variable support for window and resolution](https://jira.oci.oraclecorp.com/browse/CPD-378)

![auto-support-variables-grafana](https://user-images.githubusercontent.com/20325788/78409452-8e4f0200-75be-11ea-9f1c-68c22144acc4.gif)

----

**New  stuff** 

- Resolution now uses same components and logic of windows
in query editor
- If auto is selected in windows or resolution,
it will be replaced with a time duration acc to the config in ```constants.js```
just before sending a query to the server
 in buildQueries function for the respective field
- Variables are supported in windows and resolution drop downs and tested.

---


**Changes** 
 - Default values for window and resolution in query editor set to auto

---

 **Fixes** 
  - Updated getVariables in dataSource.js to eliminate duplicates for
  the combination variables as constants and includeCustom flag of the
  function set to false or not passed. Previously, duplicate variable names were
  being returned for the above combo.
  - Updated documentation of getVariables in dataSource.js to reflect
  the above change

---- 

**Known bugs**

-  Regions and drop downs created before this  branch creation are
appending variables to the same object of options resulting in variable duplication for every click on the drop down

----

**Tests for newly added functions**

![image](https://user-images.githubusercontent.com/20325788/78408479-1b448c00-75bc-11ea-8b73-5ac5fcb74206.png)