### PR TITLE
Fixed missing metrics by adding groupby

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -301,6 +301,8 @@ func (o *OCIDatasource) searchResponse(ctx context.Context, tsdbReq *datasource.
 		var ts GrafanaSearchRequest
 		json.Unmarshal([]byte(query.ModelJson), &ts)
 		reqDetails := monitoring.ListMetricsDetails{}
+		// Group by is needed to get all  metrics without missing any as it is limited by the max pages
+		reqDetails.GroupBy = []string{"name"}
 		reqDetails.Namespace = common.String(ts.Namespace)
 		if ts.ResourceGroup != "NoResourceGroup" {
 			reqDetails.ResourceGroup = common.String(ts.ResourceGroup)

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -42,7 +42,7 @@ grafana-cli plugins install oci-datasource
 The plugin will be installed into your Grafana plugins directory, which by default is located at /var/lib/grafana/plugins. [Here is more information on the CLI tool](http://docs.grafana.org/plugins/installation/).
 
 ### Manual installation 
-Alternatively, you can manually download the .tar file and unpack it into your /grafana/plugins directory. To do so, change to the Grafana plugins directory: `cd /usr/local/var/lib/grafana/plugins`. Download the OCI Grafana Plugin: wget `https://github.com/oracle/oci-grafana-plugin/releases/download/v2.2.2/plugin.tar`. Create a directory and install the plugin: `mkdir oci && tar -C oci -xvf plugin.tar` and then remove the tarball: `rm plugin.tar`. 
+Alternatively, you can manually download the .tar file and unpack it into your /grafana/plugins directory. To do so, change to the Grafana plugins directory: `cd /usr/local/var/lib/grafana/plugins`. Download the OCI Grafana Plugin: wget `https://github.com/oracle/oci-grafana-plugin/releases/download/v2.2.3/plugin.tar`. Create a directory and install the plugin: `mkdir oci && tar -C oci -xvf plugin.tar` and then remove the tarball: `rm plugin.tar`. 
 
 >  **Additional step for Grafana 7**. Open the grafana configuration  *grafana.ini* file and add the `allow_loading_unsigned_plugins = "oci-datasource"`in the *plugins* section.
 

--- a/docs/linuxoci.md
+++ b/docs/linuxoci.md
@@ -35,7 +35,7 @@ grafana-cli plugins install oci-metrics-datasource
 The plugin will be installed into your Grafana plugins directory, which by default is located at /var/lib/grafana/plugins. [Here is more information on the CLI tool](http://docs.grafana.org/plugins/installation/).
 
 ### Manually installation 
-Alternatively, you can manually download the .tar file and unpack it into your /grafana/plugins directory. To do so, change to the Grafana plugins directory: `cd /usr/local/var/lib/grafana/plugins`. Download the OCI Grafana Plugin: wget `https://github.com/oracle/oci-grafana-plugin/releases/download/v2.2.2/plugin.tar`. Create a directory and install the plugin: `mkdir oci && tar -C oci -xvf plugin.tar` and then remove the tarball: `rm plugin.tar`. 
+Alternatively, you can manually download the .tar file and unpack it into your /grafana/plugins directory. To do so, change to the Grafana plugins directory: `cd /usr/local/var/lib/grafana/plugins`. Download the OCI Grafana Plugin: wget `https://github.com/oracle/oci-grafana-plugin/releases/download/v2.2.3/plugin.tar`. Create a directory and install the plugin: `mkdir oci && tar -C oci -xvf plugin.tar` and then remove the tarball: `rm plugin.tar`. 
 
 >  **Additional step for Grafana 7**. Open the grafana configuration  *grafana.ini* file and add the `allow_loading_unsigned_plugins = "oci-datasource"`in the *plugins* section.
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -40,7 +40,7 @@ grafana-cli plugins install oci-metrics-datasource
 The plugin will be installed into your Grafana plugins directory, which by default is located at /var/lib/grafana/plugins. [Here is more information on the CLI tool](http://docs.grafana.org/plugins/installation/).
 
 ### Manually installation 
- Alternatively, you can manually download the .tar file and unpack it into your /grafana/plugins directory. To do so, change to the Grafana plugins directory: `cd /usr/local/var/lib/grafana/plugins`. Download the OCI Grafana Plugin: wget `https://github.com/oracle/oci-grafana-plugin/releases/download/v2.2.2/plugin.tar`. Create a directory and install the plugin: `mkdir oci && tar -C oci -xvf plugin.tar` and then remove the tarball: `rm plugin.tar`
+ Alternatively, you can manually download the .tar file and unpack it into your /grafana/plugins directory. To do so, change to the Grafana plugins directory: `cd /usr/local/var/lib/grafana/plugins`. Download the OCI Grafana Plugin: wget `https://github.com/oracle/oci-grafana-plugin/releases/download/v2.2.3/plugin.tar`. Create a directory and install the plugin: `mkdir oci && tar -C oci -xvf plugin.tar` and then remove the tarball: `rm plugin.tar`
 
 >  **Additional step for Grafana 7**. Open the grafana configuration  *grafana.ini* file and add the `allow_loading_unsigned_plugins = "oci-datasource"`in the *plugins* section.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oci-metrics-datasource",
   "private": true,
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Oracle Cloud Infrastructure Metrics Data Source for Grafana",
   "main": "index.js",
   "scripts": {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -26,8 +26,8 @@
       {"name": "GitHub", "url": "https://github.com/oracle/oci-grafana-plugin"},
       {"name": "UPL", "url": "https://oss.oracle.com/licenses/upl"}
     ],
-    "version": "2.2.2",
-    "updated": "2021-01-11"
+    "version": "2.2.3",
+    "updated": "2021-01-21"
   },
 
   "dependencies": {


### PR DESCRIPTION
**Issue** 

- A number of metrics were not fetched  previously as the group by name clause  was not present in the list metrics request.

- As the number of results received were large without a group by, the later half of the result pages were trimmed off. 

- At different times, the number of results  differ that also caused the change in number of metrics received 


**What's better now ?** 
The metrics request (dropdown click) is 20x faster as group by puts all metrics together in a single page)


[test release : plugin.tar ](https://github.com/oracle/oci-grafana-plugin/releases/tag/v2.2.3-beta)


**Screenshot of a  working chart with  metric that was not received before**

![Screenshot of working metrics graph of a metric that was not received before](https://user-images.githubusercontent.com/20325788/105429377-2aa5cc00-5c06-11eb-9868-a41e72ac6db3.png)


**After change : Screenshot that shows the bottom of the complete metrics list** 
![Screen Shot 2021-01-21 at 4 22 01 PM](https://user-images.githubusercontent.com/20325788/105429562-83756480-5c06-11eb-9966-bac98080155d.png)

**Before change : Screenshot that shows the bottom of the complete metrics list** 

![Screen Shot 2021-01-21 at 4 55 33 PM](https://user-images.githubusercontent.com/20325788/105431030-b4a36400-5c09-11eb-8621-79fc71e9a5bb.png)

