### PR TITLE
Fix backend logging: use correct levels and key-value format

### DIFF
--- a/pkg/plugin/metrics_functions.go
+++ b/pkg/plugin/metrics_functions.go
@@ -42,7 +42,7 @@ type metricDataBank struct {
 //   - error: An error if any of the tests fail, or nil if the connectivity is successful.
 func (o *OCIDatasource) TestConnectivity(ctx context.Context) error {
 	// Log the start of the test
-	backend.Logger.Error("client", "TestConnectivity", "testing the OCI connectivity")
+	backend.Logger.Debug("testing OCI connectivity", "method", "TestConnectivity")
 
 	// var reg common.Region
 	var testResult bool
@@ -71,7 +71,7 @@ func (o *OCIDatasource) TestConnectivity(ctx context.Context) error {
 		}
 
 		// Test the tenancy OCID
-		backend.Logger.Error("TestConnectivity", "ConfigKey", key, "Testing Tenancy OCID", tenancyocid)
+		backend.Logger.Debug("testing tenancy", "method", "TestConnectivity", "configKey", key, "tenancyOCID", tenancyocid)
 		listMetrics := monitoring.ListMetricsRequest{
 			CompartmentId: &tenancyocid,
 			Limit:         common.Int(25),
@@ -80,7 +80,7 @@ func (o *OCIDatasource) TestConnectivity(ctx context.Context) error {
 		var status int
 		res, err := o.tenancyAccess[key].monitoringClient.ListMetrics(ctx, listMetrics)
 		if res.RawResponse == nil || res.RawResponse.ContentLength == 0 {
-			backend.Logger.Error("TestConnectivity", "Config Key", key, "error", err)
+			backend.Logger.Error("connectivity test returned empty result", "method", "TestConnectivity", "configKey", key, "error", err)
 			return fmt.Errorf("TestConnectivity failed: result is empty %v: %v", key, err)
 		} else {
 			status = res.RawResponse.StatusCode
@@ -89,30 +89,30 @@ func (o *OCIDatasource) TestConnectivity(ctx context.Context) error {
 		// Handle errors
 		if err != nil {
 			if res.RawResponse.StatusCode == 401 {
-				backend.Logger.Error("TestConnectivity", "Config Key", key, "error", err)
+				backend.Logger.Error("connectivity test unauthorized", "method", "TestConnectivity", "configKey", key, "error", err)
 				return fmt.Errorf("TestConnectivity failed: error in profile %v: %v", key, err)
 			} else {
-				backend.Logger.Error("TestConnectivity", "Config Key", key, "SKIPPED", err)
+				backend.Logger.Warn("tenancy-level list metrics returned error, trying compartments", "method", "TestConnectivity", "configKey", key, "error", err)
 			}
 		}
 
 		// Check the status code
 		if status >= 200 && status < 300 {
-			backend.Logger.Error("TestConnectivity", "Config Key", key, "OK", status)
+			backend.Logger.Debug("tenancy connectivity test passed", "method", "TestConnectivity", "configKey", key, "status", status)
 		} else {
-			backend.Logger.Error("TestConnectivity", "Config Key", key, "SKIPPED", fmt.Sprintf("listMetrics on Tenancy %s did not work, testing compartments", tenancyocid))
+			backend.Logger.Debug("tenancy-level list metrics failed, testing compartments", "method", "TestConnectivity", "configKey", key, "tenancyOCID", tenancyocid)
 
 			// Get the compartments
 			comparts := o.GetCompartments(ctx, tenancyocid, true)
 			if comparts == nil {
-				backend.Logger.Error("TestConnectivity", "Config Key", key, "error", "could not read compartments")
+				backend.Logger.Error("could not read compartments", "method", "TestConnectivity", "configKey", key)
 				return fmt.Errorf("TestConnectivity failed: cannot read Compartments in profile %v", key)
 			}
 
 			// Test each compartment
 			for _, v := range comparts {
 				tocid := v.OCID
-				backend.Logger.Error("TestConnectivity", "Config Key", key, "Testing", tocid)
+				backend.Logger.Debug("testing compartment", "method", "TestConnectivity", "configKey", key, "compartmentOCID", tocid)
 				listMetrics := monitoring.ListMetricsRequest{
 					CompartmentId: common.String(tocid),
 					Limit:         common.Int(25),
@@ -120,21 +120,21 @@ func (o *OCIDatasource) TestConnectivity(ctx context.Context) error {
 
 				res, err := o.tenancyAccess[key].monitoringClient.ListMetrics(ctx, listMetrics)
 				if err != nil {
-					backend.Logger.Error("TestConnectivity", "Config Key", key, "SKIPPED", err)
+					backend.Logger.Warn("compartment test returned error, skipping", "method", "TestConnectivity", "configKey", key, "error", err)
 				}
 				status := res.RawResponse.StatusCode
 				if status >= 200 && status < 300 {
-					backend.Logger.Error("TestConnectivity", "Config Key", key, "OK", status)
+					backend.Logger.Debug("compartment connectivity test passed", "method", "TestConnectivity", "configKey", key, "status", status)
 					testResult = true
 					break
 				} else {
-					backend.Logger.Error("TestConnectivity", "Config Key", key, "SKIPPED", status)
+					backend.Logger.Debug("compartment test returned non-success status, skipping", "method", "TestConnectivity", "configKey", key, "status", status)
 				}
 			}
 			if testResult {
 				continue
 			} else {
-				backend.Logger.Error("TestConnectivity", "Config Key", key, "FAILED", "listMetrics failed in each compartment")
+				backend.Logger.Error("listMetrics failed in all compartments", "method", "TestConnectivity", "configKey", key)
 				return fmt.Errorf("listMetrics failed in each Compartments in profile %v", key)
 			}
 		}
@@ -206,7 +206,7 @@ Returns:
   - []models.OCIResource: A slice of OCIResource containing tenancy information.
 */
 func (o *OCIDatasource) GetTenancies(ctx context.Context) []models.OCIResource {
-	backend.Logger.Error("client", "GetTenancies", "fetching the tenancies")
+	backend.Logger.Debug("fetching tenancies", "method", "GetTenancies")
 
 	tenancyList := []models.OCIResource{}
 	for key := range o.tenancyAccess {
@@ -240,7 +240,7 @@ func (o *OCIDatasource) GetTenancies(ctx context.Context) []models.OCIResource {
 //   - []string: A slice of strings, where each string represents a subscribed region.
 //     Returns nil if any error occurred during the process.
 func (o *OCIDatasource) GetSubscribedRegions(ctx context.Context, tenancyOCID string) []string {
-	backend.Logger.Error("client", "GetSubscribedRegions", "fetching the subscribed region for tenancy: "+tenancyOCID)
+	backend.Logger.Debug("fetching subscribed regions", "method", "GetSubscribedRegions", "tenancyOCID", tenancyOCID)
 
 	var subscribedRegions []string
 	takey := o.GetTenancyAccessKey(tenancyOCID)
@@ -256,7 +256,7 @@ func (o *OCIDatasource) GetSubscribedRegions(ctx context.Context, tenancyOCID st
 		return nil
 	}
 
-	backend.Logger.Error("client", "GetSubscribedRegionstakey", "fetching the subscribed region for tenancy OCID: "+*common.String(tenancyocid))
+	backend.Logger.Debug("fetching subscribed regions for tenancy", "method", "GetSubscribedRegions", "tenancyOCID", tenancyocid)
 
 	req := identity.ListRegionSubscriptionsRequest{TenancyId: common.String(tenancyocid)}
 
@@ -278,7 +278,7 @@ func (o *OCIDatasource) GetSubscribedRegions(ctx context.Context, tenancyOCID st
 
 	for _, item := range resp.Items {
 		if item.Status == identity.RegionSubscriptionStatusReady {
-			backend.Logger.Error("client", "GetSubscribedRegionstakey", "fetching the subscribed region for regioname: "+*item.RegionName)
+			backend.Logger.Debug("found subscribed region", "method", "GetSubscribedRegions", "region", *item.RegionName)
 			subscribedRegions = append(subscribedRegions, *item.RegionName)
 		}
 	}
@@ -312,7 +312,7 @@ func (o *OCIDatasource) GetSubscribedRegions(ctx context.Context, tenancyOCID st
 //   - []models.OCIResource: A slice of OCIResource, where each element represents a compartment with its
 //     name and OCID. Returns nil if there is an error during the process.
 func (o *OCIDatasource) GetCompartments(ctx context.Context, tenancyOCID string, includeAccessibleOnly ...bool) []models.OCIResource {
-	backend.Logger.Error("client", "GetCompartments", "fetching the sub-compartments for tenancy: "+tenancyOCID)
+	backend.Logger.Debug("fetching compartments", "method", "GetCompartments", "tenancyOCID", tenancyOCID)
 
 	takey := o.GetTenancyAccessKey(tenancyOCID)
 
@@ -334,7 +334,7 @@ func (o *OCIDatasource) GetCompartments(ctx context.Context, tenancyOCID string,
 	// Send the request using the service client
 	resp, err := o.tenancyAccess[takey].identityClient.GetTenancy(context.Background(), req)
 	if err != nil {
-		backend.Logger.Error("client", "GetCompartments", "error in GetTenancy")
+		backend.Logger.Error("failed to get tenancy", "method", "GetCompartments", "error", err)
 		return nil
 	}
 
@@ -342,7 +342,7 @@ func (o *OCIDatasource) GetCompartments(ctx context.Context, tenancyOCID string,
 
 	if len(includeAccessibleOnly) == 1 && includeAccessibleOnly[0] {
 		effectiveScope = identity.ListCompartmentsAccessLevelAccessible
-		backend.Logger.Error("client", "GetCompartments", "using ListCompartmentsAccessLevelAccessible")
+		backend.Logger.Debug("using accessible-only compartment scope", "method", "GetCompartments")
 	} else {
 		effectiveScope = identity.ListCompartmentsAccessLevelAny
 	}
@@ -458,7 +458,7 @@ func (o *OCIDatasource) GetNamespaceWithMetricNames(
 	tenancyOCID string,
 	compartmentOCID string,
 	region string) []models.OCIMetricNamesWithNamespace {
-	backend.Logger.Error("client", "GetNamespaceWithMetricNames", "fetching the metric names along with namespaces under compartment: "+compartmentOCID)
+	backend.Logger.Debug("fetching namespaces and metric names", "method", "GetNamespaceWithMetricNames", "compartment", compartmentOCID)
 
 	takey := o.GetTenancyAccessKey(tenancyOCID)
 	// fetching from cache, if present
@@ -507,7 +507,7 @@ func (o *OCIDatasource) GetNamespaceWithMetricNames(
 	} else {
 		regionalClient, err := o.tenancyAccess[takey].GetMonitoringClientForRegion(region)
 		if err != nil {
-			backend.Logger.Error("client", "GetNamespaceWithMetricNames", err)
+			backend.Logger.Error("failed to get regional monitoring client", "method", "GetNamespaceWithMetricNames", "error", err)
 			return nil
 		}
 		namespaceWithMetricNames = listMetricsMetadataPerRegion(
@@ -575,7 +575,7 @@ func (o *OCIDatasource) GetNamespaceWithMetricNames(
 //   - Returns any errors encountered during API calls.
 //   - Logs errors encountered during the data retrieval process.
 func (o *OCIDatasource) GetMetricDataPoints(ctx context.Context, requestParams models.MetricsDataRequest, tenancyOCID string) ([]time.Time, []models.OCIMetricDataPoints, error) {
-	backend.Logger.Error("client", "GetMetricDataPoints", "fetching the metrics datapoints under compartment '"+requestParams.CompartmentOCID+"' for query '"+requestParams.QueryText+"'")
+	backend.Logger.Debug("fetching metric datapoints", "method", "GetMetricDataPoints", "compartment", requestParams.CompartmentOCID, "query", requestParams.QueryText)
 
 	times := []time.Time{}
 	dataValuesWithTime := map[common.SDKTime][]float64{}
@@ -642,13 +642,13 @@ func (o *OCIDatasource) GetMetricDataPoints(ctx context.Context, requestParams m
 				defer wg.Done()
 				regionalClient, err := ta.GetMonitoringClientForRegion(sRegion)
 				if err != nil {
-					backend.Logger.Error("client", "GetMetricDataPoints", err)
+					backend.Logger.Error("failed to get regional monitoring client", "method", "GetMetricDataPoints", "region", sRegion, "error", err)
 					errCh <- err
 					return
 				}
 				resp, err := regionalClient.SummarizeMetricsData(ctx, metricsDataRequest)
 				if err != nil {
-					backend.Logger.Error("client", "GetMetricDataPoints", err)
+					backend.Logger.Error("failed to summarize metrics data", "method", "GetMetricDataPoints", "region", sRegion, "error", err)
 					errCh <- err
 					return
 				}
@@ -681,7 +681,7 @@ func (o *OCIDatasource) GetMetricDataPoints(ctx context.Context, requestParams m
 			// Receive on the error channel
 			err := <-errCh
 			if err != nil {
-				backend.Logger.Error("client", "GetMetricDataPoints", err)
+				backend.Logger.Error("region metrics fetch failed", "method", "GetMetricDataPoints", "error", err)
 				return nil, nil, err
 			}
 		}
@@ -868,7 +868,7 @@ func (o *OCIDatasource) GetMetricDataPoints(ctx context.Context, requestParams m
 //
 //	An interface{} containing the cached resource.
 func (o *OCIDatasource) fetchFromCache(ctx context.Context, tenancyOCID string, compartmentOCID string, compartmentName string, region string, namespace string, suffix string) interface{} {
-	backend.Logger.Error("client", "fetchFromCache", "fetching from cache")
+	backend.Logger.Debug("fetching from cache", "method", "fetchFromCache")
 
 	labelCacheKey := strings.Join([]string{tenancyOCID, compartmentOCID, region, namespace, suffix}, "-")
 	if _, found := o.cache.Get(labelCacheKey); !found {
@@ -893,7 +893,7 @@ func (o *OCIDatasource) GetTags(
 	compartmentName string,
 	region string,
 	namespace string) []models.OCIResourceTags {
-	backend.Logger.Error("client", "GetTags", "fetching the tags for namespace '"+namespace+"'")
+	backend.Logger.Debug("fetching tags", "method", "GetTags", "namespace", namespace)
 
 	resourceTagsList := []models.OCIResourceTags{}
 	allResourceTags := map[string][]string{}
@@ -1138,7 +1138,7 @@ func (o *OCIDatasource) GetResourceGroups(
 	compartmentOCID string,
 	region string,
 	namespace string) []models.OCIMetricNamesWithResourceGroup {
-	backend.Logger.Error("client", "GetResourceGroups", "fetching the resource groups under compartment '"+compartmentOCID+"' for namespace '"+namespace+"'")
+	backend.Logger.Debug("fetching resource groups", "method", "GetResourceGroups", "compartment", compartmentOCID, "namespace", namespace)
 
 	// fetching from cache, if present
 	cacheKey := strings.Join([]string{tenancyOCID, compartmentOCID, region, namespace, "rgs"}, "-")
@@ -1181,7 +1181,7 @@ func (o *OCIDatasource) GetResourceGroups(
 	} else {
 		regionalClient, err := o.tenancyAccess[takey].GetMonitoringClientForRegion(region)
 		if err != nil {
-			backend.Logger.Error("client", "GetResourceGroups", err)
+			backend.Logger.Error("failed to get regional monitoring client", "method", "GetResourceGroups", "error", err)
 			return nil
 		}
 		metricResourceGroups = listMetricsMetadataPerRegion(
@@ -1195,7 +1195,7 @@ func (o *OCIDatasource) GetResourceGroups(
 	}
 
 	if len(metricResourceGroups) == 0 {
-		backend.Logger.Error("client", "GetResourceGroups", "resource groups under compartment '"+compartmentOCID+"' for namespace '"+namespace+"' is empty")
+		backend.Logger.Debug("no resource groups found", "method", "GetResourceGroups", "compartment", compartmentOCID, "namespace", namespace)
 		return nil
 	} else {
 		for k, v := range metricResourceGroups {
@@ -1246,11 +1246,11 @@ func (o *OCIDatasource) GetDimensions(
 	var DimensionUse string
 	var cacheSubKey string
 	if len(isLabel) > 0 {
-		backend.Logger.Error("client", "GetDimensionsLabels", "fetching the dimension under compartment '"+compartmentOCID+"' for namespace '"+namespace+"' and metric '"+metricName+"' to be used as labels")
+		backend.Logger.Debug("fetching dimensions for labels", "method", "GetDimensions", "compartment", compartmentOCID, "namespace", namespace, "metric", metricName)
 		DimensionUse = constants.FETCH_FOR_LABELDIMENSION
 		cacheSubKey = "dslabel"
 	} else {
-		backend.Logger.Error("client", "GetDimensions", "fetching the dimension under compartment '"+compartmentOCID+"' for namespace '"+namespace+"' and metric '"+metricName+"'")
+		backend.Logger.Debug("fetching dimensions", "method", "GetDimensions", "compartment", compartmentOCID, "namespace", namespace, "metric", metricName)
 		DimensionUse = constants.FETCH_FOR_DIMENSION
 		cacheSubKey = "ds"
 	}
@@ -1303,7 +1303,7 @@ func (o *OCIDatasource) GetDimensions(
 	} else {
 		regionalClient, err := o.tenancyAccess[takey].GetMonitoringClientForRegion(region)
 		if err != nil {
-			backend.Logger.Error("client", "GetDimensions", err)
+			backend.Logger.Error("failed to get regional monitoring client", "method", "GetDimensions", "error", err)
 			return nil
 		}
 		metricDimensions = listMetricsMetadataPerRegion(

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -209,19 +209,18 @@ func NewOCIDatasourceConstructor() *OCIDatasource {
 //   - instancemgmt.Instance: The created OCIDatasource instance.
 //   - error: An error if the datasource creation fails.
 func NewOCIDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-	backend.Logger.Error("plugin", "NewOCIDatasource", settings.ID)
+	backend.Logger.Debug("NewOCIDatasource", "instanceID", settings.ID)
 
 	o := NewOCIDatasourceConstructor()
 	dsSettings := &models.OCIDatasourceSettings{}
 
 	if err := dsSettings.Load(settings); err != nil {
-		backend.Logger.Error("plugin", "NewOCIDatasource", "failed to load oci datasource settings: "+err.Error())
+		backend.Logger.Error("failed to load datasource settings", "method", "NewOCIDatasource", "error", err)
 		return nil, err
 	}
 	o.settings = dsSettings
 
-	backend.Logger.Error("plugin", "dsSettings.Environment", "dsSettings.Environment: "+dsSettings.Environment)
-	backend.Logger.Error("plugin", "dsSettings.TenancyMode", "dsSettings.TenancyMode: "+dsSettings.TenancyMode)
+	backend.Logger.Debug("datasource settings loaded", "environment", dsSettings.Environment, "tenancyMode", dsSettings.TenancyMode)
 
 	if len(o.tenancyAccess) == 0 {
 		err := o.getConfigProvider(dsSettings.Environment, dsSettings.TenancyMode, settings)
@@ -237,7 +236,7 @@ func NewOCIDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt
 		Metrics:     false,
 	})
 	if err != nil {
-		backend.Logger.Error("plugin", "NewOCIDatasource", "failed to create cache: "+err.Error())
+		backend.Logger.Error("failed to create cache", "method", "NewOCIDatasource", "error", err)
 		return nil, err
 	}
 	o.cache = cache
@@ -268,7 +267,7 @@ func NewOCIDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt
 *   - If any error occurs during the query execution, it will be returned.
  */
 func (o *OCIDatasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	backend.Logger.Error("plugin", "QueryData", req.PluginContext.DataSourceInstanceSettings.Name)
+	backend.Logger.Debug("QueryData", "datasource", req.PluginContext.DataSourceInstanceSettings.Name)
 
 	// create response struct
 	response := backend.NewQueryDataResponse()
@@ -289,14 +288,14 @@ func (o *OCIDatasource) QueryData(ctx context.Context, req *backend.QueryDataReq
 // datasource configuration page which allows users to verify that
 // a datasource is working as expected.
 func (o *OCIDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	backend.Logger.Error("plugin", "CheckHealth", req.PluginContext.PluginID)
+	backend.Logger.Debug("CheckHealth", "pluginID", req.PluginContext.PluginID)
 
 	hRes := &backend.CheckHealthResult{}
 
 	if err := o.TestConnectivity(ctx); err != nil {
 		hRes.Status = backend.HealthStatusError
 		hRes.Message = err.Error()
-		backend.Logger.Error("plugin", "CheckHealth", err)
+		backend.Logger.Error("health check failed", "method", "CheckHealth", "error", err)
 		return hRes, nil
 	}
 
@@ -459,7 +458,7 @@ func (o *OCIDatasource) getConfigProvider(environment string, tenancymode string
 			var configProvider common.ConfigurationProvider
 			if tenancymode != "multitenancy" {
 				if key != "DEFAULT" {
-					backend.Logger.Error("Single Tenancy mode detected, skipping additional profile", "profile", key)
+					backend.Logger.Debug("single tenancy mode, skipping additional profile", "profile", key)
 					continue
 				}
 			}
@@ -470,7 +469,7 @@ func (o *OCIDatasource) getConfigProvider(environment string, tenancymode string
 			}
 			// Override region in Configuration Provider in case a Custom region is configured
 			if q.customregion[key] != "" {
-				backend.Logger.Error("getConfigProvider", "CustomRegion", q.customregion[key])
+				backend.Logger.Debug("using custom region", "method", "getConfigProvider", "customRegion", q.customregion[key])
 				configProvider = common.NewRawConfigurationProvider(q.tenancyocid[key], q.user[key], q.customregion[key], q.fingerprint[key], q.privkey[key], q.privkeypass[key])
 
 				// Register custom home region in SDK's global region map so that
@@ -492,7 +491,7 @@ func (o *OCIDatasource) getConfigProvider(environment string, tenancymode string
 			mrp := clientRetryPolicy()
 			monitoringClient, err := monitoring.NewMonitoringClientWithConfigurationProvider(configProvider)
 			if err != nil {
-				backend.Logger.Error("getConfigProvider", "Error with config", key)
+				backend.Logger.Error("failed to create monitoring client", "method", "getConfigProvider", "profile", key, "error", err)
 				return errors.New("error with client")
 			}
 			monitoringClient.Configuration.RetryPolicy = &mrp
@@ -568,7 +567,7 @@ func (o *OCIDatasource) getConfigProvider(environment string, tenancymode string
 		}
 		monitoringClient, err := monitoring.NewMonitoringClientWithConfigurationProvider(configProvider)
 		if err != nil {
-			backend.Logger.Error("getConfigProvider", "Error with config", SingleTenancyKey)
+			backend.Logger.Error("failed to create monitoring client", "method", "getConfigProvider", "profile", SingleTenancyKey, "error", err)
 			return errors.New("error with client")
 		}
 		identityClient, err := identity.NewIdentityClientWithConfigurationProvider(configProvider)

--- a/pkg/plugin/query.go
+++ b/pkg/plugin/query.go
@@ -35,7 +35,7 @@ import (
 // Returns:
 // - backend.DataResponse: The response containing the query results or an error if the query fails.
 func (ocidx *OCIDatasource) query(ctx context.Context, pCtx backend.PluginContext, query backend.DataQuery) backend.DataResponse {
-	backend.Logger.Error("plugin.query", "query", "query initiated for "+query.RefID)
+	backend.Logger.Debug("query initiated", "method", "query", "refID", query.RefID)
 
 	// Creating the Data response for query
 	response := backend.DataResponse{}

--- a/pkg/plugin/resource_handler.go
+++ b/pkg/plugin/resource_handler.go
@@ -99,13 +99,13 @@ func (ocidx *OCIDatasource) GetRegionsHandler(rw http.ResponseWriter, req *http.
 
 	var rr rootRequest
 	if err := jsoniter.NewDecoder(req.Body).Decode(&rr); err != nil {
-		backend.Logger.Error("plugin.resource_handler", "GetRegionsHandler", err)
+		backend.Logger.Error("failed to decode request body", "method", "GetRegionsHandler", "error", err)
 		respondWithError(rw, http.StatusBadRequest, "Failed to read request body", err)
 		return
 	}
 	regions := ocidx.GetSubscribedRegions(req.Context(), rr.Tenancy)
 	if regions == nil {
-		backend.Logger.Error("plugin.resource_handler", "GetSubscribedRegions", "Could not read regions")
+		backend.Logger.Error("could not read regions", "method", "GetRegionsHandler")
 		respondWithError(rw, http.StatusBadRequest, "Could not read regions", nil)
 		return
 	}
@@ -128,13 +128,13 @@ func (ocidx *OCIDatasource) GetCompartmentsHandler(rw http.ResponseWriter, req *
 
 	var rr rootRequest
 	if err := jsoniter.NewDecoder(req.Body).Decode(&rr); err != nil {
-		backend.Logger.Error("plugin.resource_handler", "GetCompartmentsHandler", err)
+		backend.Logger.Error("failed to decode request body", "method", "GetCompartmentsHandler", "error", err)
 		respondWithError(rw, http.StatusBadRequest, "Failed to read request body", err)
 		return
 	}
 	compartments := ocidx.GetCompartments(req.Context(), rr.Tenancy)
 	if compartments == nil {
-		backend.Logger.Error("plugin.resource_handler", "GetCompartmentsHandler", "Could not read compartments")
+		backend.Logger.Error("could not read compartments", "method", "GetCompartmentsHandler")
 		respondWithError(rw, http.StatusBadRequest, "Could not read compartments", nil)
 		return
 	}
@@ -157,7 +157,7 @@ func (ocidx *OCIDatasource) GetNamespacesHandler(rw http.ResponseWriter, req *ht
 
 	var nmr namespaceMetricRequest
 	if err := jsoniter.NewDecoder(req.Body).Decode(&nmr); err != nil {
-		backend.Logger.Error("plugin.resource_handler", "GetNamespacesHandler", err)
+		backend.Logger.Error("failed to decode request body", "method", "GetNamespacesHandler", "error", err)
 		respondWithError(rw, http.StatusBadRequest, "Failed to read request body", err)
 		return
 	}
@@ -182,7 +182,7 @@ func (ocidx *OCIDatasource) GetResourceGroupHandler(rw http.ResponseWriter, req 
 
 	var rgr resourceGroupRequest
 	if err := jsoniter.NewDecoder(req.Body).Decode(&rgr); err != nil {
-		backend.Logger.Error("plugin.resource_handler", "GetResourceGroupHandler", err)
+		backend.Logger.Error("failed to decode request body", "method", "GetResourceGroupHandler", "error", err)
 		respondWithError(rw, http.StatusBadRequest, "Failed to read request body", err)
 		return
 	}
@@ -207,7 +207,7 @@ func (ocidx *OCIDatasource) GetDimensionsHandler(rw http.ResponseWriter, req *ht
 
 	var dr dimensionRequest
 	if err := jsoniter.NewDecoder(req.Body).Decode(&dr); err != nil {
-		backend.Logger.Error("plugin.resource_handler", "GetDimensionsHandler", err)
+		backend.Logger.Error("failed to decode request body", "method", "GetDimensionsHandler", "error", err)
 		respondWithError(rw, http.StatusBadRequest, "Failed to read request body", err)
 		return
 	}
@@ -232,7 +232,7 @@ func (ocidx *OCIDatasource) GetTagsHandler(rw http.ResponseWriter, req *http.Req
 
 	var tr tagRequest
 	if err := jsoniter.NewDecoder(req.Body).Decode(&tr); err != nil {
-		backend.Logger.Error("ResourceHandler", "GetTagsHandler", err)
+		backend.Logger.Error("failed to decode request body", "method", "GetTagsHandler", "error", err)
 		respondWithError(rw, http.StatusBadRequest, "Failed to read request body", err)
 		return
 	}
@@ -250,7 +250,7 @@ func (ocidx *OCIDatasource) GetTagsHandler(rw http.ResponseWriter, req *http.Req
 func writeResponse(rw http.ResponseWriter, resp interface{}) {
 	resultJson, err := jsoniter.Marshal(resp)
 	if err != nil {
-		backend.Logger.Error("plugin.resource_handler", "writeResponse", "could not parse response:"+err.Error())
+		backend.Logger.Error("could not marshal response", "method", "writeResponse", "error", err)
 		respondWithError(rw, http.StatusInternalServerError, "Failed to convert result", err)
 	}
 
@@ -275,7 +275,7 @@ func respondWithError(rw http.ResponseWriter, statusCode int, message string, er
 
 	response, err := jsoniter.Marshal(httpError)
 	if err != nil {
-		backend.Logger.Error("plugin.resource_handler", "respondWithError", "could not parse response:"+err.Error())
+		backend.Logger.Error("could not marshal error response", "method", "respondWithError", "error", err)
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -295,7 +295,7 @@ func sendResponse(rw http.ResponseWriter, statusCode int, response []byte) {
 
 	_, err := rw.Write(response)
 	if err != nil {
-		backend.Logger.Error("plugin.resource_handler", "sendResponse", "could not write to response: "+err.Error())
+		backend.Logger.Error("could not write response", "method", "sendResponse", "error", err)
 		rw.WriteHeader(http.StatusInternalServerError)
 	}
 }

--- a/pkg/plugin/utils.go
+++ b/pkg/plugin/utils.go
@@ -57,7 +57,7 @@ func listMetrics(ctx context.Context, mClient monitoring.MonitoringClient, req m
 
 		res, err := mClient.ListMetrics(ctx, req)
 		if err != nil {
-			backend.Logger.Error("client.utils", "listMetrics", err)
+			backend.Logger.Error("failed to list metrics", "method", "listMetrics", "error", err)
 			break
 		}
 
@@ -96,7 +96,7 @@ func listMetricsMetadataFromAllRegion(
 	req monitoring.ListMetricsRequest,
 	regions []string) map[string][]string {
 
-	backend.Logger.Error("client.utils", "listMetricsMetadataFromAllRegion", "Data fetch start by calling list metrics API from all subscribed regions")
+	backend.Logger.Debug("fetching metrics metadata from all subscribed regions", "method", "listMetricsMetadataFromAllRegion")
 
 	var metricsMetadata map[string][]string
 	var allRegionsData sync.Map
@@ -110,7 +110,7 @@ func listMetricsMetadataFromAllRegion(
 
 				regionalClient, err := ta.GetMonitoringClientForRegion(sRegion)
 				if err != nil {
-					backend.Logger.Error("client.utils", "listMetricsMetadataFromAllRegion", err)
+					backend.Logger.Error("failed to get regional monitoring client", "method", "listMetricsMetadataFromAllRegion", "region", sRegion, "error", err)
 					return
 				}
 
@@ -188,7 +188,7 @@ func listMetricsMetadataPerRegion(
 	mClient monitoring.MonitoringClient,
 	req monitoring.ListMetricsRequest) map[string][]string {
 
-	backend.Logger.Error("client.utils", "listMetricsMetadataPerRegion", "Data fetch start by calling list metrics API for a particular regions")
+	backend.Logger.Debug("fetching metrics metadata for region", "method", "listMetricsMetadataPerRegion")
 	if cachedMetricsData, found := ci.Get(cacheKey); found {
 		// This check avoids the type assertion and potential panic
 		if _, ok := cachedMetricsData.(map[string][]string); ok {
@@ -361,9 +361,9 @@ func (o *OCIDatasource) GetTenancyAccessKey(tenancyOCID string) string {
 
 	_, ok := o.tenancyAccess[takey]
 	if ok {
-		backend.Logger.Error("GetTenancyAccessKey", "Valid takey", takey)
+		backend.Logger.Debug("resolved tenancy access key", "method", "GetTenancyAccessKey", "takey", takey)
 	} else {
-		backend.Logger.Error("GetTenancyAccessKey", "Invalid takey", takey)
+		backend.Logger.Warn("invalid tenancy access key", "method", "GetTenancyAccessKey", "takey", takey)
 		return ""
 	}
 


### PR DESCRIPTION
Address Grafana plugin review feedback:
- Change Logger.Error() to Logger.Debug() on expected/recoverable paths (query execution, client pool lookups, config loading, cache hits, etc.)
- Change Logger.Error() to Logger.Warn() on recoverable fallback paths
- Fix key-value format: use "error", err instead of passing err as positional argument, per Grafana plugin SDK conventions
- Reserve Logger.Error() for genuinely unexpected failures only