### PR TITLE
Fix ListCompartments pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oci-metrics-datasource",
   "private": true,
-  "version": "6.5.5",
+  "version": "6.5.6",
   "description": "Oracle Cloud Infrastructure Metrics Data Source for Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/plugin/metrics_functions.go
+++ b/pkg/plugin/metrics_functions.go
@@ -22,6 +22,43 @@ type metricDataBank struct {
 	resourceLabels map[string]map[string]string
 }
 
+func listCompartments(
+	ctx context.Context,
+	request identity.ListCompartmentsRequest,
+	list func(context.Context, identity.ListCompartmentsRequest) (identity.ListCompartmentsResponse, error),
+) ([]identity.Compartment, error) {
+	var compartments []identity.Compartment
+	restarted := false
+
+	for {
+		response, err := list(ctx, request)
+		if err != nil {
+			if request.Page != nil && !restarted && isInvalidPaginationToken(err) {
+				compartments = nil
+				request.Page = nil
+				restarted = true
+				continue
+			}
+			return nil, err
+		}
+
+		compartments = append(compartments, response.Items...)
+		if response.OpcNextPage == nil || *response.OpcNextPage == "" {
+			return compartments, nil
+		}
+		request.Page = response.OpcNextPage
+	}
+}
+
+func isInvalidPaginationToken(err error) bool {
+	serviceErr, ok := common.IsServiceError(err)
+	if !ok || serviceErr.GetHTTPStatusCode() != 400 {
+		return false
+	}
+
+	return serviceErr.GetCode() == "InvalidPaginationToken" || serviceErr.GetCode() == "InvalidParameter"
+}
+
 // TestConnectivity checks the OCI data source test request in Grafana's Datasource configuration UI.
 //
 // This function performs a connectivity test to the Oracle Cloud Infrastructure (OCI) Monitoring service.
@@ -351,31 +388,15 @@ func (o *OCIDatasource) GetCompartments(ctx context.Context, tenancyOCID string,
 
 	// calling the api if not present in cache
 	compartmentList := []models.OCIResource{}
-	var fetchedCompartments []identity.Compartment
-	var pageHeader string
-
-	for {
-		res, err := o.tenancyAccess[takey].identityClient.ListCompartments(ctx,
-			identity.ListCompartmentsRequest{
-				CompartmentId:          common.String(tenancyocid),
-				Page:                   &pageHeader,
-				AccessLevel:            effectiveScope,
-				LifecycleState:         identity.CompartmentLifecycleStateActive,
-				CompartmentIdInSubtree: common.Bool(true),
-			})
-
-		if err != nil {
-			backend.Logger.Warn("client", "GetCompartments", err)
-			break
-		}
-
-		fetchedCompartments = append(fetchedCompartments, res.Items...)
-
-		if len(res.RawResponse.Header.Get("opc-next-page")) != 0 {
-			pageHeader = *res.OpcNextPage
-		} else {
-			break
-		}
+	fetchedCompartments, err := listCompartments(ctx, identity.ListCompartmentsRequest{
+		CompartmentId:          common.String(tenancyocid),
+		AccessLevel:            effectiveScope,
+		LifecycleState:         identity.CompartmentLifecycleStateActive,
+		CompartmentIdInSubtree: common.Bool(true),
+	}, o.tenancyAccess[takey].identityClient.ListCompartments)
+	if err != nil {
+		backend.Logger.Warn("failed to list compartments", "method", "GetCompartments", "error", err)
+		return nil
 	}
 
 	compartments[tenancyocid] = *resp.Name //tenancy name

--- a/pkg/plugin/metrics_functions_test.go
+++ b/pkg/plugin/metrics_functions_test.go
@@ -1,0 +1,244 @@
+// Copyright © 2026 Oracle and/or its affiliates. All rights reserved.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+package plugin
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/identity"
+)
+
+type testServiceError struct {
+	status int
+	code   string
+}
+
+func (e testServiceError) Error() string          { return e.code }
+func (e testServiceError) GetHTTPStatusCode() int { return e.status }
+func (e testServiceError) GetMessage() string     { return e.code }
+func (e testServiceError) GetCode() string        { return e.code }
+func (e testServiceError) GetOpcRequestID() string {
+	return "test-request"
+}
+
+func compartment(id string) identity.Compartment {
+	return identity.Compartment{Id: common.String(id)}
+}
+
+func TestListCompartmentsSinglePageOmitsPage(t *testing.T) {
+	calls := 0
+	got, err := listCompartments(context.Background(), identity.ListCompartmentsRequest{}, func(
+		_ context.Context,
+		request identity.ListCompartmentsRequest,
+	) (identity.ListCompartmentsResponse, error) {
+		calls++
+		if request.Page != nil {
+			t.Fatalf("initial Page = %q, want nil", *request.Page)
+		}
+		return identity.ListCompartmentsResponse{Items: []identity.Compartment{compartment("one")}}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("listCompartments returned error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if len(got) != 1 || *got[0].Id != "one" {
+		t.Fatalf("compartments = %v, want [one]", got)
+	}
+}
+
+func TestListCompartmentsUsesNextPageToken(t *testing.T) {
+	calls := 0
+	got, err := listCompartments(context.Background(), identity.ListCompartmentsRequest{}, func(
+		_ context.Context,
+		request identity.ListCompartmentsRequest,
+	) (identity.ListCompartmentsResponse, error) {
+		calls++
+		switch calls {
+		case 1:
+			if request.Page != nil {
+				t.Fatalf("initial Page = %q, want nil", *request.Page)
+			}
+			return identity.ListCompartmentsResponse{
+				Items:       []identity.Compartment{compartment("one")},
+				OpcNextPage: common.String("next-page"),
+			}, nil
+		case 2:
+			if request.Page == nil || *request.Page != "next-page" {
+				t.Fatalf("second Page = %v, want next-page", request.Page)
+			}
+			return identity.ListCompartmentsResponse{Items: []identity.Compartment{compartment("two")}}, nil
+		default:
+			t.Fatalf("unexpected call %d", calls)
+			return identity.ListCompartmentsResponse{}, nil
+		}
+	})
+
+	if err != nil {
+		t.Fatalf("listCompartments returned error: %v", err)
+	}
+	if len(got) != 2 || *got[0].Id != "one" || *got[1].Id != "two" {
+		t.Fatalf("compartments = %v, want [one two]", got)
+	}
+}
+
+func TestListCompartmentsStopsOnEmptyNextPage(t *testing.T) {
+	calls := 0
+	got, err := listCompartments(context.Background(), identity.ListCompartmentsRequest{}, func(
+		_ context.Context,
+		_ identity.ListCompartmentsRequest,
+	) (identity.ListCompartmentsResponse, error) {
+		calls++
+		return identity.ListCompartmentsResponse{
+			Items:       []identity.Compartment{compartment("one")},
+			OpcNextPage: common.String(""),
+		}, nil
+	})
+
+	if err != nil {
+		t.Fatalf("listCompartments returned error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if len(got) != 1 || *got[0].Id != "one" {
+		t.Fatalf("compartments = %v, want [one]", got)
+	}
+}
+
+func TestListCompartmentsRestartsOnceForInvalidToken(t *testing.T) {
+	calls := 0
+	got, err := listCompartments(context.Background(), identity.ListCompartmentsRequest{}, func(
+		_ context.Context,
+		request identity.ListCompartmentsRequest,
+	) (identity.ListCompartmentsResponse, error) {
+		calls++
+		switch calls {
+		case 1:
+			return identity.ListCompartmentsResponse{
+				Items:       []identity.Compartment{compartment("discarded")},
+				OpcNextPage: common.String("stale-token"),
+			}, nil
+		case 2:
+			if request.Page == nil || *request.Page != "stale-token" {
+				t.Fatalf("second Page = %v, want stale-token", request.Page)
+			}
+			return identity.ListCompartmentsResponse{}, testServiceError{status: 400, code: "InvalidPaginationToken"}
+		case 3:
+			if request.Page != nil {
+				t.Fatalf("restart Page = %q, want nil", *request.Page)
+			}
+			return identity.ListCompartmentsResponse{
+				Items:       []identity.Compartment{compartment("one")},
+				OpcNextPage: common.String("fresh-token"),
+			}, nil
+		case 4:
+			if request.Page == nil || *request.Page != "fresh-token" {
+				t.Fatalf("fourth Page = %v, want fresh-token", request.Page)
+			}
+			return identity.ListCompartmentsResponse{Items: []identity.Compartment{compartment("two")}}, nil
+		default:
+			t.Fatalf("unexpected call %d", calls)
+			return identity.ListCompartmentsResponse{}, nil
+		}
+	})
+
+	if err != nil {
+		t.Fatalf("listCompartments returned error: %v", err)
+	}
+	if len(got) != 2 || *got[0].Id != "one" || *got[1].Id != "two" {
+		t.Fatalf("compartments = %v, want [one two]", got)
+	}
+}
+
+func TestListCompartmentsDoesNotRestartTwice(t *testing.T) {
+	calls := 0
+	got, err := listCompartments(context.Background(), identity.ListCompartmentsRequest{}, func(
+		_ context.Context,
+		request identity.ListCompartmentsRequest,
+	) (identity.ListCompartmentsResponse, error) {
+		calls++
+		if calls == 1 || calls == 3 {
+			return identity.ListCompartmentsResponse{
+				Items:       []identity.Compartment{compartment("partial")},
+				OpcNextPage: common.String("token"),
+			}, nil
+		}
+		if request.Page == nil || *request.Page != "token" {
+			t.Fatalf("Page = %v, want token", request.Page)
+		}
+		return identity.ListCompartmentsResponse{}, testServiceError{status: 400, code: "InvalidParameter"}
+	})
+
+	if err == nil {
+		t.Fatal("listCompartments returned nil error")
+	}
+	if got != nil {
+		t.Fatalf("compartments = %v, want nil", got)
+	}
+	if calls != 4 {
+		t.Fatalf("calls = %d, want 4", calls)
+	}
+}
+
+func TestListCompartmentsDoesNotRetryInitialInvalidParameter(t *testing.T) {
+	calls := 0
+	got, err := listCompartments(context.Background(), identity.ListCompartmentsRequest{}, func(
+		_ context.Context,
+		request identity.ListCompartmentsRequest,
+	) (identity.ListCompartmentsResponse, error) {
+		calls++
+		if request.Page != nil {
+			t.Fatalf("initial Page = %q, want nil", *request.Page)
+		}
+		return identity.ListCompartmentsResponse{}, testServiceError{status: 400, code: "InvalidParameter"}
+	})
+
+	if err == nil {
+		t.Fatal("listCompartments returned nil error")
+	}
+	if got != nil {
+		t.Fatalf("compartments = %v, want nil", got)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+}
+
+func TestListCompartmentsReturnsOtherErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "network", err: errors.New("network failure")},
+		{name: "service", err: testServiceError{status: 500, code: "InternalError"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			got, err := listCompartments(context.Background(), identity.ListCompartmentsRequest{}, func(
+				_ context.Context,
+				_ identity.ListCompartmentsRequest,
+			) (identity.ListCompartmentsResponse, error) {
+				calls++
+				return identity.ListCompartmentsResponse{}, test.err
+			})
+
+			if err == nil {
+				t.Fatal("listCompartments returned nil error")
+			}
+			if got != nil {
+				t.Fatalf("compartments = %v, want nil", got)
+			}
+			if calls != 1 {
+				t.Fatalf("calls = %d, want 1", calls)
+			}
+		})
+	}
+}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -23,8 +23,8 @@
       },
       { "name": "UPL", "url": "https://oss.oracle.com/licenses/upl" }
     ],
-    "version": "6.5.5",
-    "updated": "2026-06-18",
+    "version": "6.5.6",
+    "updated": "2026-07-08",
     "screenshots":[
       {
         "name":"OCI Metrics Dashboard",


### PR DESCRIPTION
## Summary

Fix `ListCompartments` pagination so the initial OCI Identity request does not send an empty `page=` token.

## Context

The plugin initialized `Page` with a pointer to an empty string. The OCI SDK serialized that as `page=`, which OCI Identity now rejects with `InvalidPaginationToken`. The error path then returned and cached only the root tenancy.

Related reports: #382, #385, #386, and #387.

## Changes

- Omit `Page` from the initial request.
- Use only `OpcNextPage` values returned by OCI for later requests.
- Restart pagination once when OCI rejects a pagination token.
- Discard partial results and return an error if pagination ultimately fails.
- Add focused tests for single-page, multi-page, empty-token, retry, and failure behavior.

## Testing

- `go test -count=1 ./pkg/plugin/...`
- `go test -count=1 ./...`
- `git diff --check`

## Impact

Child compartments populate again, and failed compartment enumeration is no longer presented or cached as a root-only success. IAM scope and frontend behavior are unchanged.

## Issue coverage

- Fully addresses #382 and #386.
- Addresses the root-only compartment-listing symptom in #385. Its Cross Tenancy and least-privilege configuration concerns are separate.
- Addresses the empty `page=` / `InvalidPaginationToken` failure in #387. Its tenancy-root `ListMetrics` expensive-request failure and literal `DEFAULT/` compartment ID are separate issues.
- Does not address #353, which is a separate Monitoring `ListMetrics` request problem, or #337, which fails while listing regions.
